### PR TITLE
Allow selecting providers to connect to + devices to connect to.

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -9,7 +9,7 @@
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
-
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.AnimatedTabControl.xaml" />
                 <!-- accent resource -->
                 <!-- change "Cobalt" to the accent color you want -->
 

--- a/Aura/AuraDevice.cs
+++ b/Aura/AuraDevice.cs
@@ -21,6 +21,10 @@ namespace Aura
             this.internalAuraDevice = internalAuraDevice;
         }
 
+        public AuraDevice()
+        {
+        }
+
         public override Task Connect()
         {
             return Task.CompletedTask;

--- a/Aura/AuraDevice.cs
+++ b/Aura/AuraDevice.cs
@@ -12,6 +12,8 @@ namespace Aura
     {
         private readonly HashSet<OperationType> auraSupportedOps = new HashSet<OperationType>() { OperationType.SetColor };
 
+        public override string DeviceName => "Unknown Aura Device";
+
         public override HashSet<OperationType> SupportedOperations => auraSupportedOps;
 
         private readonly AuraSDKDotNet.AuraDevice internalAuraDevice;

--- a/Aura/AuraProvider.cs
+++ b/Aura/AuraProvider.cs
@@ -19,7 +19,7 @@ namespace Aura
             return Task.FromResult<IEnumerable<Device>>(internalSdk.Motherboards.Select(mb => new AuraDevice(mb)));
         }
 
-        public override Task Register()
+        protected override Task Register()
         {
             internalSdk = new AuraSDK();
             return Task.CompletedTask;

--- a/Corsair/Device/CorsairDevice.cs
+++ b/Corsair/Device/CorsairDevice.cs
@@ -16,6 +16,8 @@ namespace Corsair.Device
 	/// </summary>
 	public class CorsairDevice : Infrastructure.Device
 	{
+		public override string DeviceName => Native.model != null ? Marshal.PtrToStringAuto(Native.model): "Unknown";
+
 		#region Corsair Native
 
 		internal CorsairDeviceNative Native;

--- a/Corsair/Provider/CorsairProvider.cs
+++ b/Corsair/Provider/CorsairProvider.cs
@@ -7,7 +7,7 @@ namespace Corsair.Provider
 	public class CorsairProvider : Infrastructure.Provider
 	{
 		public override string ProviderName => "Corsair Sync";
-		public override Task Register()
+		protected override Task Register()
 		{
 			CUESDK.CUESDK.PerformProtocolHandshake();
 

--- a/Infrastructure/Device.cs
+++ b/Infrastructure/Device.cs
@@ -9,6 +9,7 @@ namespace Infrastructure
 {
     public abstract class Device
     {
+        public abstract string DeviceName { get; }
         public abstract HashSet<OperationType> SupportedOperations { get; }
         public abstract Color GetColor();
         public abstract void SetColor(Color color);

--- a/Infrastructure/MusicEffect.cs
+++ b/Infrastructure/MusicEffect.cs
@@ -92,7 +92,7 @@ namespace Infrastructure
             {
                 if (device.SupportedOperations.Contains(OperationType.SetBrightness))
                 {
-                    tasks.Add(Task.Run(() => device.SetBrightnessPercentage((byte)(max * 100))));
+                    tasks.Add(Task.Run(() => device.SetBrightnessPercentage((byte)(max))));
                 }
 
                 if (device.SupportedOperations.Contains(OperationType.SetColor))

--- a/Infrastructure/Provider.cs
+++ b/Infrastructure/Provider.cs
@@ -8,9 +8,35 @@ namespace Infrastructure
 {
     public abstract class Provider
     {
+        public bool IsRegistered { get; private set; }
+
         public abstract string ProviderName { get; }
-        public abstract Task Register();
         public abstract Task Unregister();
         public abstract Task<IEnumerable<Device>> Discover();
+
+        public async Task InitializeProvider()
+        {
+            try
+            {
+                if (IsRegistered)
+                {
+                    return;
+                }
+
+                await Register();
+
+                IsRegistered = true;
+            }
+            catch(Exception)
+            {
+
+            }
+            finally
+            {
+
+            }    
+        }
+
+        protected abstract Task Register();
     }
 }

--- a/Logitech/LogitechHeadsetDevice.cs
+++ b/Logitech/LogitechHeadsetDevice.cs
@@ -12,6 +12,8 @@ namespace Logitech
     {
         private readonly HashSet<OperationType> logitechSupportedOps = new HashSet<OperationType>() { OperationType.SetColor, OperationType.SetBrightness };
 
+        public override string DeviceName => throw new NotImplementedException();
+
         public override HashSet<OperationType> SupportedOperations => logitechSupportedOps;
 
         public override Task Connect()

--- a/Logitech/LogitechKeyboardDevice.cs
+++ b/Logitech/LogitechKeyboardDevice.cs
@@ -12,6 +12,8 @@ namespace Logitech
     {
         private readonly HashSet<OperationType> logitechSupportedOps = new HashSet<OperationType>() { OperationType.SetColor, OperationType.SetBrightness };
 
+        public override string DeviceName => throw new NotImplementedException();
+
         public override HashSet<OperationType> SupportedOperations => logitechSupportedOps;
 
         public override Task Connect()

--- a/Logitech/LogitechMouseDevice.cs
+++ b/Logitech/LogitechMouseDevice.cs
@@ -12,6 +12,8 @@ namespace Logitech
     {
         private readonly HashSet<OperationType> logitechSupportedOps = new HashSet<OperationType>() { OperationType.SetColor };
 
+        public override string DeviceName => "Logitech Mouse";
+
         public override HashSet<OperationType> SupportedOperations => logitechSupportedOps;
 
         public override Task Connect()

--- a/Logitech/LogitechMousematDevice.cs
+++ b/Logitech/LogitechMousematDevice.cs
@@ -12,6 +12,8 @@ namespace Logitech
     {
         private readonly HashSet<OperationType> logitechSupportedOps = new HashSet<OperationType>() { OperationType.SetColor, OperationType.SetBrightness };
 
+        public override string DeviceName => throw new NotImplementedException();
+
         public override HashSet<OperationType> SupportedOperations => logitechSupportedOps;
 
         public override Task Connect()

--- a/Logitech/LogitechProvider.cs
+++ b/Logitech/LogitechProvider.cs
@@ -44,7 +44,7 @@ namespace Logitech
            */
         }
 
-        public override Task Register()
+        protected override Task Register()
         {
             // Initialize the LED SDK
             bool LedInitialized = LogitechGSDK.LogiLedInit();

--- a/Logitech/LogitechSpeakerDevice.cs
+++ b/Logitech/LogitechSpeakerDevice.cs
@@ -12,6 +12,8 @@ namespace Logitech
     {
         private readonly HashSet<OperationType> logitechSupportedOps = new HashSet<OperationType>() { OperationType.SetColor, OperationType.SetBrightness };
 
+        public override string DeviceName => throw new NotImplementedException();
+
         public override HashSet<OperationType> SupportedOperations => logitechSupportedOps;
 
         public override Task Connect()

--- a/MagicHome/MagicHomeDevice.cs
+++ b/MagicHome/MagicHomeDevice.cs
@@ -10,7 +10,7 @@ namespace MagicHome
     public class MagicHomeDevice : Device
     {
         private Light InternalLight;
-        public override HashSet<OperationType> SupportedOperations => new HashSet<OperationType>() { OperationType.SetColor, OperationType.SetBrightness };
+        public override HashSet<OperationType> SupportedOperations => new HashSet<OperationType>() { OperationType.SetColor/*, OperationType.SetBrightness*/ };
 
         public MagicHomeDevice(Light InternalLight)
         {

--- a/MagicHome/MagicHomeDevice.cs
+++ b/MagicHome/MagicHomeDevice.cs
@@ -10,6 +10,9 @@ namespace MagicHome
     public class MagicHomeDevice : Device
     {
         private Light InternalLight;
+
+        public override string DeviceName => "Magic Home Device";
+
         public override HashSet<OperationType> SupportedOperations => new HashSet<OperationType>() { OperationType.SetColor/*, OperationType.SetBrightness*/ };
 
         public MagicHomeDevice(Light InternalLight)

--- a/MagicHome/MagicHomeProvider.cs
+++ b/MagicHome/MagicHomeProvider.cs
@@ -32,7 +32,7 @@ namespace MagicHome
             return Task.FromResult<IEnumerable<Device>>(internalDevices.Select(internalDevice => new MagicHomeDevice(internalDevice)));
         }
 
-        public override Task Register()
+        protected override Task Register()
         {
             return Task.CompletedTask;
         }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -43,13 +43,30 @@
                         <ColumnDefinition Width="50*" />
                         <ColumnDefinition Width="50*" />
                     </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="80*" />
+                        <RowDefinition Height="20*" />
+                    </Grid.RowDefinitions>
 
-                    <ItemsControl Grid.Column="0" Grid.Row="0" ItemsSource="{Binding providers, Path=ProviderName}">
+                    <ItemsControl Grid.Column="0" Grid.Row="0" Name="providersItemsControl">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <StackPanel>
+                                <StackPanel Orientation="Horizontal">
+                                    <CheckBox Checked="CheckProviderForDiscovery_Clicked" Unchecked="UncheckProviderForDiscovery_Clicked" Tag="{Binding}"></CheckBox>
                                     <TextBlock Text="{Binding ProviderName}"></TextBlock>
-                                    <Button Click="DiscoverDevicesFromProvider_Clicked" Tag="{Binding}">Discover devices</Button>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <Button Grid.Column="0" Grid.Row="1" Click="DiscoverDevices_Clicked">Discover devices</Button>
+
+                    <ItemsControl Grid.Column="1" Grid.Row="0" ItemsSource="{Binding}" Name="devicesControl">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <CheckBox Checked="CheckDevice_Clicked" Unchecked="UncheckDevice_Clicked" Tag="{Binding}"></CheckBox>
+                                    <TextBlock>Test</TextBlock>
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -66,7 +66,7 @@
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal">
                                     <CheckBox Checked="CheckDevice_Clicked" Unchecked="UncheckDevice_Clicked" Tag="{Binding}"></CheckBox>
-                                    <TextBlock>Test</TextBlock>
+                                    <TextBlock Text="{Binding DeviceName}"></TextBlock>
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -7,30 +7,66 @@
         xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
                       xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
                       mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
+        Title="MainWindow" Height="720" Width="1280">
     <Grid>
-        <Controls:FlipView x:Name="EffectFlipView"
+        <TabControl TabStripPlacement="Top">
+            <TabItem Header="Effects">
+                <Grid>
+                    <Controls:FlipView x:Name="EffectFlipView"
                    Foreground="{DynamicResource WhiteBrush}"
                    Height="200"
-                    Margin="0,20,0,199" SelectionChanged="EffectFlipView_SelectionChanged">
-            <Controls:FlipView.Items>
-                <Grid Background="#2E8DEF">
-                    <iconPacks:PackIconModern Width="60"
+                    Margin="0,120,0,324" SelectionChanged="EffectFlipView_SelectionChanged">
+                        <Controls:FlipView.Items>
+                            <Grid Background="#2E8DEF" Margin="0,-22,0,0">
+                                <iconPacks:PackIconModern Width="60"
                                       Height="60"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
                                       Kind="MusicWifi" />
-                </Grid>
-                <Grid Background="#2E8DEF">
-                    <iconPacks:PackIconModern Width="60"
+                            </Grid>
+                            <Grid Background="#2E8DEF">
+                                <iconPacks:PackIconModern Width="60"
                                       Height="60"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
                                       Kind="CursorDefault" />
+                            </Grid>
+                        </Controls:FlipView.Items>
+                    </Controls:FlipView>
+                    <Button Style="{DynamicResource AccentedSquareButtonStyle}" x:Name="StartSyncBtn" Content="Start Syncing" HorizontalAlignment="Left" Margin="552,463,0,0" VerticalAlignment="Top" Width="142" Click="StartSyncBtn_Click"/>
+                    <Button Style="{DynamicResource AccentedSquareButtonStyle}" x:Name="StopSyncingBtn" Content="Stop Syncing" HorizontalAlignment="Left" Margin="552,532,0,0" VerticalAlignment="Top" Width="142" Click="StopSyncingBtn_Click"/>
                 </Grid>
-            </Controls:FlipView.Items>
-        </Controls:FlipView>
-        <Button Style="{DynamicResource AccentedSquareButtonStyle}" x:Name="StartSyncBtn" Content="Start Syncing" HorizontalAlignment="Left" Margin="357,255,0,0" VerticalAlignment="Top" Width="142" Click="StartSyncBtn_Click"/>
-        <Button Style="{DynamicResource AccentedSquareButtonStyle}" x:Name="StopSyncingBtn" Content="Stop Syncing" HorizontalAlignment="Left" Margin="357,314,0,0" VerticalAlignment="Top" Width="142" Click="StopSyncingBtn_Click"/>
+            </TabItem>
+            <TabItem Header="Devices">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="50*" />
+                        <ColumnDefinition Width="50*" />
+                    </Grid.ColumnDefinitions>
+
+                    <ItemsControl Grid.Column="0" Grid.Row="0" ItemsSource="{Binding providers, Path=ProviderName}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel>
+                                    <TextBlock Text="{Binding ProviderName}"></TextBlock>
+                                    <Button Click="DiscoverDevicesFromProvider_Clicked" Tag="{Binding}">Discover devices</Button>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                </Grid>
+                <!-- <ItemsControl ItemsSource="{Binding}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel>
+                                <TextBlock Text="{Binding ProviderName}"></TextBlock>
+                                <Button Click="DiscoverDevicesFromProvider_Clicked" Tag="{Binding}">Discover devices</Button>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl> -->
+            </TabItem>
+        </TabControl>
     </Grid>
 </Controls:MetroWindow>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -45,9 +45,10 @@ namespace chroma_yeelight
     /// </summary>
     public partial class MainWindow : MetroWindow
     {
-        private IEnumerable<Provider> providers;
+        public IEnumerable<Provider> providers;
         private IEnumerable<Device> selectedDevices;
         private IEffect selectedEffect;
+        private Dictionary<Provider, IEnumerable<Device>> providerToDevices = new Dictionary<Provider, IEnumerable<Device>>();
 
         public MainWindow()
         {
@@ -59,6 +60,21 @@ namespace chroma_yeelight
             }
 
             this.providers = GetProviders();
+
+            DataContext = this.providers;
+        }
+
+        private async void DiscoverDevicesFromProvider_Clicked(object sender, RoutedEventArgs e)
+        {
+            MessageBox.Show("Hhhh LoL XD");
+
+            var button = (Button)sender;
+            var provider = (Provider)button.Tag;
+
+            await provider.Register();
+            var devices = await provider.Discover();
+
+            providerToDevices[provider] = devices;
         }
 
         private async void StartSyncBtn_Click(object sender, RoutedEventArgs e)

--- a/Msi/Devices/MLDevice.cs
+++ b/Msi/Devices/MLDevice.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Threading.Tasks;
 using Infrastructure;
@@ -9,6 +10,8 @@ namespace Msi.Devices
 {
 	public class MLDevice : Device
 	{
+		public override string DeviceName => Type;
+
 		public string Type { get; set; }
 		public MLLed[] Leds { get; set; }
 

--- a/Msi/Provider/MLProvider.cs
+++ b/Msi/Provider/MLProvider.cs
@@ -9,7 +9,7 @@ namespace Msi.Provider
 	{
 		public override string ProviderName => "MSI Sync";
 
-		public override Task Register()
+		protected override Task Register()
 		{
 			MysticLightSdk.Initialize();
 

--- a/RazerChroma/RazerChromaDevice.cs
+++ b/RazerChroma/RazerChromaDevice.cs
@@ -11,6 +11,9 @@ namespace RazerChroma
     public class RazerChromaDevice : Device
     {
         private readonly HashSet<OperationType> chromaSupportedOps = new HashSet<OperationType>() { OperationType.SetColor };
+
+        public override string DeviceName => "All Razer Chroma connected devices";
+
         public override HashSet<OperationType> SupportedOperations => chromaSupportedOps;
 
         private readonly IChroma internalChromaDriver;

--- a/RazerChroma/RazerChromaProvider.cs
+++ b/RazerChroma/RazerChromaProvider.cs
@@ -19,7 +19,7 @@ namespace RazerChroma
             return Task.FromResult<IEnumerable<Device>>(new List<Device>(1) { new RazerChromaDevice(internalChromaProvider) });
         }
 
-        public async override Task Register()
+        protected async override Task Register()
         {
             internalChromaProvider = await ColoreProvider.CreateNativeAsync();
         }

--- a/Yeelight/YeelightDevice.cs
+++ b/Yeelight/YeelightDevice.cs
@@ -17,6 +17,8 @@ namespace Yeelight
     {
         private readonly HashSet<OperationType> yeelightSupportedOps = new HashSet<OperationType>() { OperationType.GetBrightness, OperationType.SetBrightness, OperationType.GetColor, OperationType.SetColor };
 
+        public override string DeviceName => InternalDevice.Name;
+
         public override HashSet<OperationType> SupportedOperations => yeelightSupportedOps;
 
         /// <summary>

--- a/Yeelight/YeelightProvider.cs
+++ b/Yeelight/YeelightProvider.cs
@@ -18,7 +18,7 @@ namespace Yeelight
             return (await DeviceLocator.Discover()).Select(device => new YeelightDevice(device));
         }
 
-        public override Task Register()
+        protected override Task Register()
         {
             return Task.CompletedTask;
         }


### PR DESCRIPTION
This is a small and temporary modification to the UI (which will be re-written in UWP anyway).
This allows users to control the devices, on which effects are applied, by -
* Choosing which providers of devices to use - chroma/yeelight/aura/corsair etc.
* After discovery of the selected providers, choose the desired devices on which effects are ran.

This is, once again, a very ugly and small modification to allow upcoming users who stumble upon this project (although still unstable) to use this program easily.

Changelog -

* Allow users to select which providers & corresponding devices an effect is applied to.
* Fixed an issue where registering to the same provider twice may sometime crash the app (since every provider is based on completely different SDKs/APIs/Natives).